### PR TITLE
Update BlueCryptor dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Packages
 SwiftJWT.xcodeproj
 *.DS_Store
 Package.resolved
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Kitura/BlueRSA.git", from: "1.0.200"),
-        .package(url: "https://github.com/Kitura/BlueCryptor.git", from: "1.0.0"),
+        .package(url: "https://github.com/Kitura/BlueCryptor.git", from: "2.0.1"),
         .package(url: "https://github.com/Kitura/BlueECC.git", from: "1.1.0"),
         .package(url: "https://github.com/Kitura/LoggerAPI.git", from: "1.7.0"),
         .package(url: "https://github.com/Kitura/KituraContracts.git", from: "1.2.200")


### PR DESCRIPTION
> Related to https://github.com/Kitura/BlueCryptor/issues/70.

This PR updates the Cryptor dependency, thus suppressing the <kbd>Invalid Exclude</kbd> compiler warnings.
Cryptor has moved to a new major version, therefore the current Swift-JWT package manifest doesn't pick up the new Cryptor 2.0.1 update .

I also took this opportunity to add <kbd>.swiftpm</kbd> into <kbd>.gitignore</kbd>.
