### PR TITLE
Implement `LocalizedError` on `JWTError` / Fix `localizedDescription` on `Error` type

### DIFF
--- a/Sources/SwiftJWT/JWTError.swift
+++ b/Sources/SwiftJWT/JWTError.swift
@@ -19,10 +19,10 @@ import Foundation
 // MARK: JWTError
 
 /// A struct representing the different errors that can be thrown by SwiftJWT
-public struct JWTError: Error, Equatable {
+public struct JWTError: LocalizedError, Equatable {
 
     /// A human readable description of the error.
-    public let localizedDescription: String
+    public let errorDescription: String?
     
     private let internalError: InternalError
     
@@ -31,25 +31,25 @@ public struct JWTError: Error, Equatable {
     }
     
     /// Error when an invalid JWT String is provided
-    public static let invalidJWTString = JWTError(localizedDescription: "Input was not a valid JWT String", internalError: .invalidJWTString)
+    public static let invalidJWTString = JWTError(errorDescription: "Input was not a valid JWT String", internalError: .invalidJWTString)
     
     /// Error when the JWT signiture fails verification.
-    public static let failedVerification = JWTError(localizedDescription: "JWT verifier failed to verify the JWT String signiture", internalError: .failedVerification)
+    public static let failedVerification = JWTError(errorDescription: "JWT verifier failed to verify the JWT String signiture", internalError: .failedVerification)
     
     /// Error when using RSA encryption with an OS version that is too low.
-    public static let osVersionToLow = JWTError(localizedDescription: "macOS 10.12.0 (Sierra) or higher or iOS 10.0 or higher is required by CryptorRSA", internalError: .osVersionToLow)
+    public static let osVersionToLow = JWTError(errorDescription: "macOS 10.12.0 (Sierra) or higher or iOS 10.0 or higher is required by CryptorRSA", internalError: .osVersionToLow)
     
     /// Error when an invalid private key is provided for RSA encryption.
-    public static let invalidPrivateKey = JWTError(localizedDescription: "Provided private key could not be used to sign JWT", internalError: .invalidPrivateKey)
+    public static let invalidPrivateKey = JWTError(errorDescription: "Provided private key could not be used to sign JWT", internalError: .invalidPrivateKey)
     
     /// Error when the provided Data cannot be decoded to a String
-    public static let invalidUTF8Data = JWTError(localizedDescription: "Could not decode Data from UTF8 to String", internalError: .invalidData)
+    public static let invalidUTF8Data = JWTError(errorDescription: "Could not decode Data from UTF8 to String", internalError: .invalidData)
     
     /// Error when the KeyID field `kid` in the JWT header fails to generate a JWTSigner or JWTVerifier
-    public static let invalidKeyID = JWTError(localizedDescription: "The JWT KeyID `kid` header failed to generate a JWTSigner/JWTVerifier", internalError: .invalidKeyID)
+    public static let invalidKeyID = JWTError(errorDescription: "The JWT KeyID `kid` header failed to generate a JWTSigner/JWTVerifier", internalError: .invalidKeyID)
     
     /// Error when a PEM string is provided without the expected PEM headers/footers. (e.g. -----BEGIN PRIVATE KEY-----)
-    public static let missingPEMHeaders = JWTError(localizedDescription: "The provided key did not have the expected PEM headers/footers", internalError: .missingPEMHeaders)
+    public static let missingPEMHeaders = JWTError(errorDescription: "The provided key did not have the expected PEM headers/footers", internalError: .missingPEMHeaders)
     
     /// Function to check if JWTErrors are equal. Required for equatable protocol.
     public static func == (lhs: JWTError, rhs: JWTError) -> Bool {

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -141,6 +141,7 @@ class TestJWT: XCTestCase {
             ("testValidateClaims", testValidateClaims),
             ("testValidateClaimsLeeway", testValidateClaimsLeeway),
             ("testErrorPattenMatching", testErrorPattenMatching),
+            ("testTypeErasedErrorLocalizedDescription", testTypeErasedErrorLocalizedDescription),
         ]
     }
 
@@ -618,6 +619,11 @@ class TestJWT: XCTestCase {
         } catch {
             XCTFail("Incorrect error thrown: \(error)")
         }
+    }
+    
+    func testTypeErasedErrorLocalizedDescription() {
+        let error = JWTError.invalidJWTString
+        XCTAssertEqual((error as Error).localizedDescription, error.errorDescription)
     }
 }
 


### PR DESCRIPTION
This PR implements the `LocalizedError` protocol, required for `localizedDescription` to function properly when treated as a generic `Error` type.